### PR TITLE
prometheusの読み込み設定追加

### DIFF
--- a/blog-deployment.yml
+++ b/blog-deployment.yml
@@ -10,6 +10,9 @@ spec:
     metadata:
       labels:
         name: blog
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9913'
     spec:
       containers:
         - name: blog


### PR DESCRIPTION
PrometheusからNginx-exporterの値を読むため、NginxのDeploymentsにAnnotationを追加する。